### PR TITLE
READY UNSTABLE : Break cycle dependency

### DIFF
--- a/proto/wtools/amid/l3/git/include/Basic.ss
+++ b/proto/wtools/amid/l3/git/include/Basic.ss
@@ -11,7 +11,7 @@ if( typeof module !== 'undefined' )
 
   _.include( 'wCopyable' );
   _.include( 'wProcess' );
-  _.include( 'wFiles' );
+  _.include( 'wFilesBasic' );
 
   module[ 'exports' ] = _global_.wTools;
 }

--- a/was.package.json
+++ b/was.package.json
@@ -27,7 +27,7 @@
     "wTools": "",
     "wprocess": "",
     "wfilesarchive": "",
-    "wFiles": "",
+    "wFilesBasic": "",
     "wCopyable": "",
     "ini": "=2.0.0",
     "@octokit/rest": "=18.5.2"

--- a/will.yml
+++ b/will.yml
@@ -294,8 +294,8 @@ submodule:
   wCopyable:
     path: 'npm:///wCopyable'
     enabled: 0
-  wFiles:
-    path: 'npm:///wFiles'
+  wFilesBasic:
+    path: 'npm:///wfilesbasic'
     enabled: 0
   wfilesarchive:
     path: 'npm:///wfilesarchive'


### PR DESCRIPTION
Before accepting, the module `FilesBasic` should be published and module `Files` should be split into low and high parts